### PR TITLE
Fix Corepack setup and pin pnpm 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10.26.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:26-bookworm-slim AS builder
 
-RUN corepack enable && corepack prepare pnpm@10 --activate
+RUN npm install --global corepack@0.35.0 \
+    && corepack enable \
+    && corepack install --global pnpm@10.26.2
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bokken.io",
   "private": true,
+  "packageManager": "pnpm@10.26.2",
   "scripts": {
     "dev": "pnpm --filter astro dev",
     "build": "pnpm --filter astro build",


### PR DESCRIPTION
## Summary

- Pin pnpm to 10.26.2 in package.json and GitHub Actions
- Install Corepack 0.35.0 explicitly in the Node.js 26 Docker builder
- Replace the deprecated Corepack prepare command with install --global

## Commits

- `chore: pin pnpm version`: align package metadata and CI on pnpm 10.26.2
- `fix: install current Corepack in Docker`: use a Corepack release containing the current npm signing keys

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check package.json .github/workflows/ci.yml`
- `pnpm --filter astro exec astro check`
- `pnpm --filter astro exec tsc --noEmit`
- `pnpm --filter astro build`